### PR TITLE
Change default version to 4.1, and add Ubuntu 20.04 for the versioned projects

### DIFF
--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -9,7 +9,7 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: '4.0', description: 'Source for different "SUSE-Manager-Tools" packages', name: 'manager_tools_source_version')
+        string(defaultValue: '4.1', description: 'Source for different "SUSE-Manager-Tools" packages', name: 'manager_tools_source_version')
         string(defaultValue: '', description: 'Maintenance Update version (i.a. 4.0.5)', name: 'mu_version')
     }
 
@@ -58,6 +58,7 @@ pipeline {
                 echo 'Run services for SUSE-Manager-Tools Salt packages'
                 sh "osc -A https://api.suse.de service remoterun Devel:Galaxy:Manager:${params.manager_tools_source_version}:Ubuntu16.04-SUSE-Manager-Tools salt"
                 sh "osc -A https://api.suse.de service remoterun Devel:Galaxy:Manager:${params.manager_tools_source_version}:Ubuntu18.04-SUSE-Manager-Tools salt"
+                sh "osc -A https://api.suse.de service remoterun Devel:Galaxy:Manager:${params.manager_tools_source_version}:Ubuntu20.04-SUSE-Manager-Tools salt"
                 sh "osc -A https://api.suse.de service remoterun Devel:Galaxy:Manager:Head:Ubuntu16.04-SUSE-Manager-Tools salt"
                 sh "osc -A https://api.suse.de service remoterun Devel:Galaxy:Manager:Head:Ubuntu18.04-SUSE-Manager-Tools salt"
                 sh "osc -A https://api.suse.de service remoterun Devel:Galaxy:Manager:Head:Ubuntu20.04-SUSE-Manager-Tools salt"


### PR DESCRIPTION
Reasons:

1. 4.1 IBS project already exists.
2. We won't submit anymore from 4.0 IBS (remember, next submission from HEAD, then next from 4.1)
3. I didn't change the MU parameter to `4.1.X` because next promotion will still need to be `4.0.7` even if submitted from Head.