### PR TITLE
Add hardcoded 3000

### DIFF
--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -9,8 +9,8 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: '3000', description: 'Salt version', name: 'salt_version')
-        string(defaultValue: '', description: 'Maintenance Update version (i.a. 4.0.5)', name: 'mu_version')
+        string(defaultValue: '3000', description: 'Salt version to promote from products:testing to products.', name: 'salt_version')
+        string(defaultValue: '', description: 'SUSE Manager maintenance update version that this Salt update is released with, e.g. 4.1.7', name: 'mu_version')
     }
 
     agent { label 'manager-jenkins-node' }

--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -30,6 +30,11 @@ pipeline {
                 sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian:python2/salt/_service?expand=1 | grep MU-${mu_version}"
                 sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian:python3/salt/_service?expand=1 | grep MU-${mu_version}"
 
+                echo "Check that 'products:3000:testing', 'products:3000:testing:debian', and 'products:3000:testing:debian:python3' are not set to MU branches"
+                sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:3000:testing/salt/_service?expand=1 | grep MU-${mu_version}"
+                sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:3000:testing:debian/salt/_service?expand=1 | grep MU-${mu_version}"
+                sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:3000:testing:debian:python3/salt/_service?expand=1 | grep MU-${mu_version}"
+
                 echo "Check the source tarball is properly named to salt_${salt_version}.orig.tar.gz in 'products:testing:debian', 'products:testing:debian:python2' and 'products:testing:debian:python3'"
                 sh "curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian/salt/_service?expand=1 | grep salt_${salt_version}.orig.tar.g"
                 sh "curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian:python2/salt/_service?expand=1 | grep salt_${salt_version}.orig.tar.g"
@@ -52,6 +57,13 @@ pipeline {
                 sh "osc copypac systemsmanagement:saltstack:products:testing py26-compat-msgpack-python systemsmanagement:saltstack:products"
                 sh "osc copypac systemsmanagement:saltstack:products:testing py27-compat-salt systemsmanagement:saltstack:products"
                 sh "osc copypac systemsmanagement:saltstack:products:old:testing salt systemsmanagement:saltstack:products:old"
+            }
+        }
+
+        stage('Promote Salt 3000 testing RPM packages') {
+            steps {
+                echo 'Promote Salt 3000 testing packages from "products:3000:testing" to "products:3000"'
+                sh "osc copypac systemsmanagement:saltstack:products:3000:testing salt systemsmanagement:saltstack:products:3000"
             }
         }
 
@@ -123,6 +135,54 @@ pipeline {
                 }
             }
         }
+
+        stage('Promote Salt 3000 testing DEB packages') {
+            steps {
+                dir('/tmp/salt-promote-pipeline-env') {
+                    echo 'Disable services in "products:3000:testing:debian"'
+                    sh "osc co systemsmanagement:saltstack:products:3000:testing:debian salt"
+                    dir('/tmp/salt-promote-pipeline-env/systemsmanagement:saltstack:products:3000:testing:debian/salt') {
+                        sh "cp _service _service.backup"
+                        sh "sed -i 's/name=\"download_url\">/name=\"download_url\" mode=\"disabled\">/g' _service"
+
+                        echo 'Execute disabled services to ensure tarball is updated in "products:3000:testing:debian"'
+                        sh "osc service disabledrun || true"
+                        sh "osc add salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Disable services and temporary add tarball before promoting'"
+
+                        echo 'Promote "products:3000:testing:debian" package'
+                        sh "osc copypac systemsmanagement:saltstack:products:3000:testing:debian salt systemsmanagement:saltstack:products:3000:debian"
+
+                        echo 'Re-enable services in "products:3000:testing:debian"'
+                        sh "cp _service.backup _service"
+                        sh "osc rm salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Remove tarball and disable service after promoting'"
+                    }
+                    sh "rm systemsmanagement:saltstack:products:3000:testing:debian/salt -rf"
+
+                    echo 'Disable services in "products:3000:testing:debian:python3"'
+                    sh "osc co systemsmanagement:saltstack:products:3000:testing:debian:python3 salt"
+                    dir('/tmp/salt-promote-pipeline-env/systemsmanagement:saltstack:products:3000:testing:debian:python3/salt') {
+                        sh "cp _service _service.backup"
+                        sh "sed -i 's/name=\"download_url\">/name=\"download_url\" mode=\"disabled\">/g' _service"
+
+                        echo 'Execute disabled services to ensure tarball is updated in "products:3000:testing:debian:python3"'
+                        sh "osc service disabledrun || true"
+                        sh "osc add salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Disable services and temporary add tarball before promoting'"
+
+                        echo 'Promote "products:3000:testing:debian:python3" package'
+                        sh "osc copypac systemsmanagement:saltstack:products:3000:testing:debian:python3 salt systemsmanagement:saltstack:products:3000:debian:python3"
+
+                        echo 'Re-enable services in "products:3000:testing:debian:python3"'
+                        sh "cp _service.backup _service"
+                        sh "osc rm salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Remove tarball and disable service after promoting'"
+                    }
+                    sh "rm systemsmanagement:saltstack:products:3000:testing:debian:python3/salt -rf"
+                }
+            }
+        }
     }
 
     post {
@@ -133,6 +193,10 @@ pipeline {
             sh "osc linkpac systemsmanagement:saltstack:products salt systemsmanagement:saltstack:products:debian:python2 -f"
             echo 'Fix package link at promoted "products:debian:python3" package'
             sh "osc linkpac systemsmanagement:saltstack:products salt systemsmanagement:saltstack:products:debian:python3 -f"
+            echo 'Fix package link at promoted "products:3000:debian" package'
+            sh "osc linkpac systemsmanagement:saltstack:products:3000 salt systemsmanagement:saltstack:products:3000:debian -f"
+            echo 'Fix package link at promoted "products:3000:debian:python3" package'
+            sh "osc linkpac systemsmanagement:saltstack:products:3000 salt systemsmanagement:saltstack:products:3000:debian:python3 -f"
             echo 'Remove OBS environment at /tmp/salt-promote-pipeline-env'
             sh "rm /tmp/salt-promote-pipeline-env -rf || true"
         }

--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -57,85 +57,85 @@ pipeline {
 
         stage('Promote Salt testing DEB packages') {
             steps {
-			    dir('/tmp/salt-promote-pipeline-env') {
-					echo 'Disable services in "products:testing:debian"'
-					sh "osc co systemsmanagement:saltstack:products:testing:debian salt"
-			        dir('/tmp/salt-promote-pipeline-env/systemsmanagement:saltstack:products:testing:debian/salt') {
-						sh "cp _service _service.backup"
-						sh "sed -i 's/name=\"download_url\">/name=\"download_url\" mode=\"disabled\">/g' _service"
+                dir('/tmp/salt-promote-pipeline-env') {
+                    echo 'Disable services in "products:testing:debian"'
+                    sh "osc co systemsmanagement:saltstack:products:testing:debian salt"
+                    dir('/tmp/salt-promote-pipeline-env/systemsmanagement:saltstack:products:testing:debian/salt') {
+                        sh "cp _service _service.backup"
+                        sh "sed -i 's/name=\"download_url\">/name=\"download_url\" mode=\"disabled\">/g' _service"
 
-						echo 'Execute disabled services to ensure tarball is updated in "products:testing:debian"'
-						sh "osc service disabledrun || true"
-						sh "osc add salt_${salt_version}.orig.tar.gz"
-						sh "osc commit -m 'Disable services and temporary add tarball before promoting'"
+                        echo 'Execute disabled services to ensure tarball is updated in "products:testing:debian"'
+                        sh "osc service disabledrun || true"
+                        sh "osc add salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Disable services and temporary add tarball before promoting'"
 
-						echo 'Promote "products:testing:debian" package'
-						sh "osc copypac systemsmanagement:saltstack:products:testing:debian salt systemsmanagement:saltstack:products:debian"
+                        echo 'Promote "products:testing:debian" package'
+                        sh "osc copypac systemsmanagement:saltstack:products:testing:debian salt systemsmanagement:saltstack:products:debian"
 
-						echo 'Re-enable services in "products:testing:debian"'
-						sh "cp _service.backup _service"
-						sh "osc rm salt_${salt_version}.orig.tar.gz"
-						sh "osc commit -m 'Remove tarball and disable service after promoting'"
-					}
-					sh "rm systemsmanagement:saltstack:products:testing:debian/salt -rf"
+                        echo 'Re-enable services in "products:testing:debian"'
+                        sh "cp _service.backup _service"
+                        sh "osc rm salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Remove tarball and disable service after promoting'"
+                    }
+                    sh "rm systemsmanagement:saltstack:products:testing:debian/salt -rf"
 
-					echo 'Disable services in "products:testing:debian:python2"'
-					sh "osc co systemsmanagement:saltstack:products:testing:debian:python2 salt"
-			        dir('/tmp/salt-promote-pipeline-env/systemsmanagement:saltstack:products:testing:debian:python2/salt') {
-						sh "cp _service _service.backup"
-						sh "sed -i 's/name=\"download_url\">/name=\"download_url\" mode=\"disabled\">/g' _service"
+                    echo 'Disable services in "products:testing:debian:python2"'
+                    sh "osc co systemsmanagement:saltstack:products:testing:debian:python2 salt"
+                    dir('/tmp/salt-promote-pipeline-env/systemsmanagement:saltstack:products:testing:debian:python2/salt') {
+                        sh "cp _service _service.backup"
+                        sh "sed -i 's/name=\"download_url\">/name=\"download_url\" mode=\"disabled\">/g' _service"
 
-						echo 'Execute disabled services to ensure tarball is updated in "products:testing:debian:python2"'
-						sh "osc service disabledrun || true"
-						sh "osc add salt_${salt_version}.orig.tar.gz"
-						sh "osc commit -m 'Disable services and temporary add tarball before promoting'"
+                        echo 'Execute disabled services to ensure tarball is updated in "products:testing:debian:python2"'
+                        sh "osc service disabledrun || true"
+                        sh "osc add salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Disable services and temporary add tarball before promoting'"
 
-						echo 'Promote "products:testing:debian:python2" package'
-						sh "osc copypac systemsmanagement:saltstack:products:testing:debian:python2 salt systemsmanagement:saltstack:products:debian:python2"
+                        echo 'Promote "products:testing:debian:python2" package'
+                        sh "osc copypac systemsmanagement:saltstack:products:testing:debian:python2 salt systemsmanagement:saltstack:products:debian:python2"
 
-						echo 'Re-enable services in "products:testing:debian:python2"'
-						sh "cp _service.backup _service"
-						sh "osc rm salt_${salt_version}.orig.tar.gz"
-						sh "osc commit -m 'Remove tarball and disable service after promoting'"
-					}
-					sh "rm systemsmanagement:saltstack:products:testing:debian:python2/salt -rf"
+                        echo 'Re-enable services in "products:testing:debian:python2"'
+                        sh "cp _service.backup _service"
+                        sh "osc rm salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Remove tarball and disable service after promoting'"
+                    }
+                    sh "rm systemsmanagement:saltstack:products:testing:debian:python2/salt -rf"
 
-					echo 'Disable services in "products:testing:debian:python3"'
-					sh "osc co systemsmanagement:saltstack:products:testing:debian:python3 salt"
-			        dir('/tmp/salt-promote-pipeline-env/systemsmanagement:saltstack:products:testing:debian:python3/salt') {
-						sh "cp _service _service.backup"
-						sh "sed -i 's/name=\"download_url\">/name=\"download_url\" mode=\"disabled\">/g' _service"
+                    echo 'Disable services in "products:testing:debian:python3"'
+                    sh "osc co systemsmanagement:saltstack:products:testing:debian:python3 salt"
+                    dir('/tmp/salt-promote-pipeline-env/systemsmanagement:saltstack:products:testing:debian:python3/salt') {
+                        sh "cp _service _service.backup"
+                        sh "sed -i 's/name=\"download_url\">/name=\"download_url\" mode=\"disabled\">/g' _service"
 
-						echo 'Execute disabled services to ensure tarball is updated in "products:testing:debian:python3"'
-						sh "osc service disabledrun || true"
-						sh "osc add salt_${salt_version}.orig.tar.gz"
-						sh "osc commit -m 'Disable services and temporary add tarball before promoting'"
+                        echo 'Execute disabled services to ensure tarball is updated in "products:testing:debian:python3"'
+                        sh "osc service disabledrun || true"
+                        sh "osc add salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Disable services and temporary add tarball before promoting'"
 
-						echo 'Promote "products:testing:debian:python3" package'
-						sh "osc copypac systemsmanagement:saltstack:products:testing:debian:python3 salt systemsmanagement:saltstack:products:debian:python3"
+                        echo 'Promote "products:testing:debian:python3" package'
+                        sh "osc copypac systemsmanagement:saltstack:products:testing:debian:python3 salt systemsmanagement:saltstack:products:debian:python3"
 
-						echo 'Re-enable services in "products:testing:debian:python3"'
-						sh "cp _service.backup _service"
-						sh "osc rm salt_${salt_version}.orig.tar.gz"
-						sh "osc commit -m 'Remove tarball and disable service after promoting'"
-					}
-					sh "rm systemsmanagement:saltstack:products:testing:debian:python3/salt -rf"
-				}
+                        echo 'Re-enable services in "products:testing:debian:python3"'
+                        sh "cp _service.backup _service"
+                        sh "osc rm salt_${salt_version}.orig.tar.gz"
+                        sh "osc commit -m 'Remove tarball and disable service after promoting'"
+                    }
+                    sh "rm systemsmanagement:saltstack:products:testing:debian:python3/salt -rf"
+                }
             }
         }
     }
 
-	post {
-		always {
-			echo 'Fix package link at promoted "products:debian" package'
-			sh "osc linkpac systemsmanagement:saltstack:products salt systemsmanagement:saltstack:products:debian -f"
-			echo 'Fix package link at promoted "products:debian:python2" package'
-			sh "osc linkpac systemsmanagement:saltstack:products salt systemsmanagement:saltstack:products:debian:python2 -f"
-			echo 'Fix package link at promoted "products:debian:python3" package'
-			sh "osc linkpac systemsmanagement:saltstack:products salt systemsmanagement:saltstack:products:debian:python3 -f"
-			echo 'Remove OBS environment at /tmp/salt-promote-pipeline-env'
-			sh "rm /tmp/salt-promote-pipeline-env -rf || true"
-		}
+    post {
+        always {
+            echo 'Fix package link at promoted "products:debian" package'
+            sh "osc linkpac systemsmanagement:saltstack:products salt systemsmanagement:saltstack:products:debian -f"
+            echo 'Fix package link at promoted "products:debian:python2" package'
+            sh "osc linkpac systemsmanagement:saltstack:products salt systemsmanagement:saltstack:products:debian:python2 -f"
+            echo 'Fix package link at promoted "products:debian:python3" package'
+            sh "osc linkpac systemsmanagement:saltstack:products salt systemsmanagement:saltstack:products:debian:python3 -f"
+            echo 'Remove OBS environment at /tmp/salt-promote-pipeline-env'
+            sh "rm /tmp/salt-promote-pipeline-env -rf || true"
+        }
     }
 
 }

--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -16,12 +16,12 @@ pipeline {
     agent { label 'manager-jenkins-node' }
 
     stages {
-        stage('Previous checks') {
+        stage('Initial Checks') {
             steps {
-                echo "Check if 'openSUSE-MU-${mu_version}' branch exists at https://github.com/openSUSE/salt"
+                echo "Check that 'openSUSE-MU-${mu_version}' branch exists at https://github.com/openSUSE/salt"
                 sh "curl -I --fail https://codeload.github.com/openSUSE/salt/tar.gz/openSUSE-MU-${mu_version}"
 
-                echo "Check if 'MU-${mu_version}' branch exists at https://github.com/openSUSE/salt-packaging"
+                echo "Check that 'MU-${mu_version}' branch exists at https://github.com/openSUSE/salt-packaging"
                 sh "curl -I --fail https://codeload.github.com/openSUSE/salt-packaging/tar.gz/MU-${mu_version}"
 
                 echo "Check that 'products:testing', 'products:testing:debian', 'products:testing:debian:python2' and 'products:testing:debian:python3' are not set to MU branches"


### PR DESCRIPTION
This is hardcoded just temporarily. There will be a period where both 3002.2 and 3000 are maintained in parellel until we have are ready to ship Salt with a virtualenv bundled.

Salt 3002.2 is incompatible with Python 2 and older Python 3 versions, for distros that don't have the required Salt 3002.2 dependies Salt 3000 is used.

